### PR TITLE
Add check whether the prequisite GOMEA still exists

### DIFF
--- a/gomea/src/discrete/gomeaIMS.cpp
+++ b/gomea/src/discrete/gomeaIMS.cpp
@@ -300,6 +300,11 @@ void gomeaIMS::writeStatistics( int population_index )
     double population_constraint_var = GOMEAs[population_index]->getConstraintValueVariance();
     solution_t<double> *best_solution = GOMEAs[population_index]->getBestSolution();
     solution_t<double> *worst_solution = GOMEAs[population_index]->getWorstSolution();*/
+	if ( GOMEAs.size() <= population_index )
+	{
+		// GOMEA in question has terminated already - no statistics available to save.
+		return;
+	}
 
 	assert( sharedInformationInstance != NULL );
 	int key = numberOfStatisticsWrites;


### PR DESCRIPTION
If a time limit was reached, for example, the GOMEA in question seems to already have been deallocated.
This causes a nullpointer access, resulting in a segfault.

I will note however, that the time limit check does not seem to be working properly in any case - triggering too early: it does not seem to be setting a starting-timestamp, so it terminates quite early.