### PR TITLE
Increased BBOFitnessFunction precision from float to double

### DIFF
--- a/gomea/fitness.pxd
+++ b/gomea/fitness.pxd
@@ -124,8 +124,8 @@ cdef class GBOFitnessFunctionRealValued(GBOFitnessFunction):
     pass
 
 cdef class BBOFitnessFunction(FitnessFunction):
-    cpdef float objective_function( self, int objective_index, np.ndarray variables ) except? INFINITY
-    cpdef float constraint_function( self, np.ndarray variables ) except? INFINITY
+    cpdef double objective_function( self, int objective_index, np.ndarray variables ) except? INFINITY
+    cpdef double constraint_function( self, np.ndarray variables ) except? INFINITY
 
 cdef class BBOFitnessFunctionDiscrete(BBOFitnessFunction):
     pass

--- a/gomea/fitness.pyx
+++ b/gomea/fitness.pyx
@@ -117,10 +117,10 @@ cdef class GBOFitnessFunctionRealValued(GBOFitnessFunction):
         del self.c_inst_realvalued
 
 cdef class BBOFitnessFunction(FitnessFunction):
-    cpdef float objective_function( self, int objective_index, np.ndarray variables ) except? INFINITY:
+    cpdef double objective_function( self, int objective_index, np.ndarray variables ) except? INFINITY:
         return INFINITY
     
-    cpdef float constraint_function( self, np.ndarray variables ) except? INFINITY:
+    cpdef double constraint_function( self, np.ndarray variables ) except? INFINITY:
         return 0
 
 cdef class BBOFitnessFunctionDiscrete(BBOFitnessFunction):


### PR DESCRIPTION
This was already supported by the [C++ code](https://github.com/CWI-EvolutionaryIntelligence/GOMEA/blob/e67c4d4538e8e2f7de2000366e7f01d123d18a09/gomea/src/fitness/py_bbo_fitness.hpp#L19), but the [Python bindings](https://github.com/CWI-EvolutionaryIntelligence/GOMEA/blob/e67c4d4538e8e2f7de2000366e7f01d123d18a09/gomea/fitness.pyx#L119) restricted the precision to float.